### PR TITLE
Allow non-null assertions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,5 +5,8 @@ module.exports = {
 	root: true,
 	settings: {
 		react: {version: "detect"}
+	},
+	rules: {
+		"@typescript-eslint/no-non-null-assertion": "off"
 	}
 };


### PR DESCRIPTION
I didn't realize these were banned by the default linting configuration. Unless someone objects, I think we should allow these. Should resolve the one lint error on main