### PR TITLE
fix bypassed error codes in CI

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ echo
 echo "###############"
 echo "Running webpack"
 echo "###############"
-npm run build || ( echo "Webpack failed"; exit 1; )
+npm run build || { echo "Webpack failed"; exit 1; }
 
 echo
 echo "###########################"

--- a/clean.sh
+++ b/clean.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-exit 127
+
+rm -dfr dist

--- a/install.sh
+++ b/install.sh
@@ -8,21 +8,21 @@ echo
 echo "###############"
 echo "Installing node"
 echo "###############"
-sudo apt install nodejs || ( echo "Install node failed"; exit 1; )
+sudo apt install nodejs || { echo "Install node failed"; exit 1; }
 echo "node version installed: $(node -v)"
 
 echo
 echo "##############"
 echo "Installing npm"
 echo "##############"
-sudo apt install npm || ( echo "Install npm failed"; exit 1; )
+sudo apt install npm || { echo "Install npm failed"; exit 1; }
 echo "npm version installed: $(npm -v)"
 
 echo
 echo "#######################"
 echo "Installing dependencies"
 echo "#######################"
-npm install || ( echo "Install dependencies failed"; exit 1; )
+npm install || { echo "Install dependencies failed"; exit 1; }
 
 echo
 echo "######################################"


### PR DESCRIPTION
I noticed Webpack compilation failures weren't causing the build script to exit 1. It turns out the previous use of parentheses only caused a subshell to exit and not the shell the script was executing in.

Also, implemented clean.sh since it was already there and did nothing.