### PR TITLE
implement camera flight controls

### DIFF
--- a/src/RenderView.tsx
+++ b/src/RenderView.tsx
@@ -1,8 +1,18 @@
 import * as THREE from "three";
 import * as React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { PointerLockControls } from "three/examples/jsm/controls/PointerLockControls";
 
 import { MarkerFileData } from "./DataTypes";
+
+/* Axis reference */     /* THREE's relation to trial subject */
+//THREE X == COBR -X     (+left/-right)
+//THREE Y == COBR Z      (+up/-down)
+//THREE Z == COBR Y      (+front/-back)
+
+const THREExAxis = new THREE.Vector3(1, 0, 0);
+const THREEyAxis = new THREE.Vector3(0, 1, 0);
+const THREEzAxis = new THREE.Vector3(0, 0, 1);
 
 interface Props {
 	data: MarkerFileData;
@@ -14,16 +24,14 @@ export default function RenderView(props: Props) {
 	const height = 450;
 
 	const [camera] = useState(() => {
-		const result = new THREE.PerspectiveCamera(70, width / height);
-		result.position.x = 1.35; //+subject's right, -subject's left
-		result.position.y = -0.4; //+subject's front, -subject's back
-		result.position.z = 0.9; //+subject's up, -subject's down
-
-		result.rotation.x = -1.5; //tilt (+down, -up)
-		result.rotation.y = 0.9; //yaw (+CW, -CCW)
-		result.rotation.z = Math.PI; //roll (+CCW, -CW) cam @ 0 is upside-down with respect to data
-
-		return result;
+		const cam = new THREE.PerspectiveCamera(70, width / height);
+		cam.position.x = -2.0;
+		cam.position.y = 1.5;
+		cam.position.z = 0.0;
+		cam.rotateOnWorldAxis(THREExAxis, -Math.PI/8);
+		cam.rotateOnWorldAxis(THREEyAxis, -Math.PI/2);
+		cam.rotateOnWorldAxis(THREEzAxis, 0.0);
+		return cam;
 	});
 
 	const [scene] = useState(() => {
@@ -53,9 +61,9 @@ export default function RenderView(props: Props) {
 			const pos = frameData.positions[idx];
 			if(pos === null) return;
 
-			pointRep.position.x = pos.x;
-			pointRep.position.y = pos.y;
-			pointRep.position.z = pos.z;
+			pointRep.position.x = -pos.x; //COBR x-axis is inverted with respect to THREE's
+			pointRep.position.y = pos.z; //COBR z-axis is THREE's y-axis (up direction)
+			pointRep.position.z = pos.y; //COBR y-axis is THREE's z-axis (forward direction)
 		});
 	}, [pointsRep, props.data, props.frame]);
 		
@@ -65,6 +73,59 @@ export default function RenderView(props: Props) {
 		result.setSize(width, height);
 		return result;
 	});
+
+	const [cameraControls] = useState(() => new PointerLockControls(camera, renderer.domElement));
+
+	/* Use camera controls */
+	useEffect(() => {
+		const moveMeters = 0.05;
+		/* Only allow flight while mouse is in visualization area */
+		renderer.domElement.addEventListener('mouseenter', () => document.addEventListener("keydown", keyPressHandler, false), false);
+		renderer.domElement.addEventListener('mouseleave', () => document.removeEventListener("keydown", keyPressHandler, false), false);
+		/* Flight controls (keys) */
+		const keyPressHandler = (e: KeyboardEvent) => {
+			switch (e.key) {
+				/* Fly left */
+				case "a": //for right-handed mouse use
+				case "4": //for left-handed mouse use
+				case "Left": //IE/Edge specific value
+				case "ArrowLeft": cameraControls.moveRight(-moveMeters); break; //ambi/intuitive control
+				/* Fly right */
+				case "d": //for right-handed mouse use
+				case "6": //for left-handed mouse use
+				case "Right": //IE/Edge specific value
+				case "ArrowRight": cameraControls.moveRight(moveMeters); break; //ambi/intuitive control
+				/* Fly forward */
+				case "w": //for right-handed mouse use
+				case "8": //for left-handed mouse use
+				case "Up": //IE/Edge specific value
+				case "ArrowUp": cameraControls.moveForward(moveMeters); break; //ambi/intuitive control
+				/* Fly backward */
+				case "s": //for right-handed mouse use
+				case "5": //for left-handed mouse use
+				case "Down": //IE/Edge specific value
+				case "ArrowDown": cameraControls.moveForward(-moveMeters); break; //ambi/intuitive control
+				/* Fly down */
+				case "q": //for right-handed mouse use
+				case "7": //for left-handed mouse use
+				case "PageDown": camera.position.y -= moveMeters; break; //ambi/intuitive control
+				/* Fly up */
+				case "e": //for right-handed mouse use
+				case "9": //for left-handed mouse use
+				case "PageUp": camera.position.y += moveMeters; break; //ambi/intuitive control
+			}
+		};
+		/* Flight controls (mouse) */
+		renderer.domElement.addEventListener('wheel', e => {
+			const scaleFactor = 4;
+			if (e.deltaY > 0)
+				cameraControls.moveForward(-moveMeters * scaleFactor);
+			else
+				cameraControls.moveForward(moveMeters * scaleFactor);
+		}, false);
+		/* Look controls */
+		// TBD
+	}, [cameraControls,camera,renderer]);
 
 	const animationLoop = useCallback(() => {
 		renderer.render(scene, camera);

--- a/src/RenderView.tsx
+++ b/src/RenderView.tsx
@@ -88,30 +88,36 @@ export default function RenderView(props: Props) {
 				/* Fly left */
 				case "KeyA": //for right-handed mouse use
 				case "Digit4": //for left-handed mouse use
+				case "Numpad4":
 				case "Left": //IE/Edge specific value
 				case "ArrowLeft": cameraControls.moveRight(-moveMeters); break; //ambi/intuitive control
 				/* Fly right */
 				case "KeyD": //for right-handed mouse use
 				case "Digit6": //for left-handed mouse use
+				case "Numpad6":
 				case "Right": //IE/Edge specific value
 				case "ArrowRight": cameraControls.moveRight(moveMeters); break; //ambi/intuitive control
 				/* Fly forward */
 				case "KeyW": //for right-handed mouse use
 				case "Digit8": //for left-handed mouse use
+				case "Numpad8":
 				case "Up": //IE/Edge specific value
 				case "ArrowUp": cameraControls.moveForward(moveMeters); break; //ambi/intuitive control
 				/* Fly backward */
 				case "KeyS": //for right-handed mouse use
 				case "Digit5": //for left-handed mouse use
+				case "Numpad5":
 				case "Down": //IE/Edge specific value
 				case "ArrowDown": cameraControls.moveForward(-moveMeters); break; //ambi/intuitive control
 				/* Fly down */
 				case "KeyQ": //for right-handed mouse use
 				case "Digit7": //for left-handed mouse use
+				case "Numpad7":
 				case "PageDown": camera.position.y -= moveMeters; break; //ambi/intuitive control
 				/* Fly up */
 				case "KeyE": //for right-handed mouse use
 				case "Digit9": //for left-handed mouse use
+				case "Numpad9":
 				case "PageUp": camera.position.y += moveMeters; break; //ambi/intuitive control
 			}
 		};

--- a/src/RenderView.tsx
+++ b/src/RenderView.tsx
@@ -80,8 +80,8 @@ export default function RenderView(props: Props) {
 	useEffect(() => {
 		const moveMeters = 0.05;
 		/* Only allow flight while mouse is in visualization area */
-		renderer.domElement.addEventListener('mouseenter', () => document.addEventListener("keydown", keyPressHandler, false), false);
-		renderer.domElement.addEventListener('mouseleave', () => document.removeEventListener("keydown", keyPressHandler, false), false);
+		const mouseEnterVizAreaHandler = () => document.addEventListener('keydown', keyPressHandler, false);
+		const mouseLeaveVizAreaHandler = () => document.removeEventListener('keydown', keyPressHandler, false);
 		/* Flight controls (keys) */
 		const keyPressHandler = (e: KeyboardEvent) => {
 			switch (e.key) {
@@ -116,15 +116,26 @@ export default function RenderView(props: Props) {
 			}
 		};
 		/* Flight controls (mouse) */
-		renderer.domElement.addEventListener('wheel', e => {
+		const mouseWheelHandler = (e: WheelEvent) => {
 			const scaleFactor = 4;
 			if (e.deltaY > 0)
 				cameraControls.moveForward(-moveMeters * scaleFactor);
 			else
 				cameraControls.moveForward(moveMeters * scaleFactor);
-		}, false);
+		}
 		/* Look controls */
 		// TBD
+		/* Add listeners */
+		renderer.domElement.addEventListener('mouseenter', mouseEnterVizAreaHandler, false);
+		renderer.domElement.addEventListener('mouseleave', mouseLeaveVizAreaHandler, false);
+		renderer.domElement.addEventListener('wheel', mouseWheelHandler, false);
+		/* Clean up old listeners if re-rendering */
+		return () => {
+			document.removeEventListener('keydown', keyPressHandler, false);
+			renderer.domElement.removeEventListener('mouseenter', mouseEnterVizAreaHandler, false);
+			renderer.domElement.removeEventListener('mouseleave', mouseLeaveVizAreaHandler, false);
+			renderer.domElement.removeEventListener('wheel', mouseWheelHandler, false);
+		};
 	}, [cameraControls,camera,renderer]);
 
 	const animationLoop = useCallback(() => {

--- a/src/RenderView.tsx
+++ b/src/RenderView.tsx
@@ -84,34 +84,34 @@ export default function RenderView(props: Props) {
 		const mouseLeaveVizAreaHandler = () => document.removeEventListener('keydown', keyPressHandler, false);
 		/* Flight controls (keys) */
 		const keyPressHandler = (e: KeyboardEvent) => {
-			switch (e.key) {
+			switch (e.code) {
 				/* Fly left */
-				case "a": //for right-handed mouse use
-				case "4": //for left-handed mouse use
+				case "KeyA": //for right-handed mouse use
+				case "Digit4": //for left-handed mouse use
 				case "Left": //IE/Edge specific value
 				case "ArrowLeft": cameraControls.moveRight(-moveMeters); break; //ambi/intuitive control
 				/* Fly right */
-				case "d": //for right-handed mouse use
-				case "6": //for left-handed mouse use
+				case "KeyD": //for right-handed mouse use
+				case "Digit6": //for left-handed mouse use
 				case "Right": //IE/Edge specific value
 				case "ArrowRight": cameraControls.moveRight(moveMeters); break; //ambi/intuitive control
 				/* Fly forward */
-				case "w": //for right-handed mouse use
-				case "8": //for left-handed mouse use
+				case "KeyW": //for right-handed mouse use
+				case "Digit8": //for left-handed mouse use
 				case "Up": //IE/Edge specific value
 				case "ArrowUp": cameraControls.moveForward(moveMeters); break; //ambi/intuitive control
 				/* Fly backward */
-				case "s": //for right-handed mouse use
-				case "5": //for left-handed mouse use
+				case "KeyS": //for right-handed mouse use
+				case "Digit5": //for left-handed mouse use
 				case "Down": //IE/Edge specific value
 				case "ArrowDown": cameraControls.moveForward(-moveMeters); break; //ambi/intuitive control
 				/* Fly down */
-				case "q": //for right-handed mouse use
-				case "7": //for left-handed mouse use
+				case "KeyQ": //for right-handed mouse use
+				case "Digit7": //for left-handed mouse use
 				case "PageDown": camera.position.y -= moveMeters; break; //ambi/intuitive control
 				/* Fly up */
-				case "e": //for right-handed mouse use
-				case "9": //for left-handed mouse use
+				case "KeyE": //for right-handed mouse use
+				case "Digit9": //for left-handed mouse use
 				case "PageUp": camera.position.y += moveMeters; break; //ambi/intuitive control
 			}
 		};


### PR DESCRIPTION
When the mouse cursor is in the viz area you can fly using:
```
Right-handed mouse:
"w" -> forward (or mouse wheel)
"a" -> left
"s" -> backward (or mouse wheel)
"d" -> right
"q" -> down
"e" -> up

Left-handed mouse (with num-pad):
"8" -> forward (or mouse wheel)
"4" -> left
"5" -> backward (or mouse wheel)
"6" -> right
"7" -> down
"9" -> up

Ambi/intuitive:
"🠩" -> forward (or mouse wheel)
"🠨" -> left
"🠫" -> backward (or mouse wheel)
"🠪" -> right
"PageDown" -> down
"PageUp" -> up
```

## As mentioned in Discord, this PR addresses the coordinate system conversion:
One further discovery is that all 3 axes in COBR's coordinate system are different than THREE's:
```
THREE.x -> COBR.-x
THREE.y -> COBR.z
THREE.z -> COBR.y
```
Unfortunately there doesn't appear to be a neat solution for changing THREE's coordinate system (see https://discourse.threejs.org/t/convert-from-one-coordinate-system-to-another/13240), so it seems to me like the most natural approach would be to just do the translation when assigning x,y,z to each marker mesh. That way we can use all of THREE's provided assets like the camera, grid, axis helper, etc in their natural orientation and not have to worry about applying odd rotations to everything.