### PR TITLE
Set package name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-	"name": "f22-viz-kids-1",
+	"name": "movilo",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "movilo",
 			"dependencies": {
 				"@fontsource/goldman": "^4.5.9",
 				"html-webpack-plugin": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+	"name": "movilo",
 	"dependencies": {
 		"@fontsource/goldman": "^4.5.9",
 		"html-webpack-plugin": "^5.5.0",


### PR DESCRIPTION
This should avoid the issue where package-lock.json gets changed if your clone directory has a different name