### PR TITLE
display sdp info on logo click

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -121,7 +121,7 @@ body {
          font-size: inherit;
          white-space: pre-line;
          display: flex;
-         flex-direction: column; //display toggled between flex and none in App.tsx
+         flex-direction: column;
          justify-content: center;
          align-items: center;
          text-align: center;

--- a/src/App.scss
+++ b/src/App.scss
@@ -9,6 +9,9 @@ $outputAreaBGColor: #4d4d4d9d;
 $vizAreaBGColor: #222222;
 $errorPopupTextColor: #aa0000;
 $errorPopupBGColor: #202020cc;
+$sdpInfoPopupBGColor: #00329e;
+$sdpInfoPopupTextColor: #ffffff;
+$sdpLinkColor: #d74309;
 $playButtonBGColor: #6aa84f;
 $timelineTrackBGColor: #4d4d4d;
 $timelineTrackThumbColor: white;
@@ -85,22 +88,49 @@ body {
 	  }
    }
    #popup-area {
+      $popupPadding: 15px;
+      $popupZindex: 1;
+      z-index: $popupZindex;
       grid-row: 2/4;
       grid-column: 1/3;
-      z-index: 1;
+      position: relative; //base for child popups' absolute positioning
+      font-size: 9pt; //for child popups to inherit
       visibility: hidden;
       #error-popup {
-         z-index: 2;
-         padding: 15px;
-         white-space: pre;
-         overflow: scroll;
-         color: $errorPopupTextColor;
+         z-index: calc($popupZindex + 1);
+         position: absolute;
+         padding: $popupPadding;
+         width: calc(100% - 2*$popupPadding);
+         height: calc(100% - 2*$popupPadding);
+         overflow: auto;
          background-color: $errorPopupBGColor;
-         width: 770px;
-         height: 420px;
+         color: $errorPopupTextColor;
          font-family: 'monospace','sans-serif';
-         font-size: 9pt;
+         font-size: inherit;
+         white-space: pre;
          cursor: text;
+      }
+      #sdp-info-popup {
+         z-index: calc($popupZindex + 2);
+         position: absolute;
+         padding: $popupPadding;
+         width: calc(100% - 2*$popupPadding);
+         height: calc(100% - 2*$popupPadding);
+         background-color: $sdpInfoPopupBGColor;
+         color: $sdpInfoPopupTextColor;
+         font-size: inherit;
+         white-space: pre-line;
+         display: flex;
+         flex-direction: column; //display toggled between flex and none in App.tsx
+         justify-content: center;
+         align-items: center;
+         text-align: center;
+         a {
+            text-decoration: none;
+            color: $sdpLinkColor;
+            font-size: inherit;
+            font-weight: bold;
+         }
       }
    }
    #output-area {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ export default function App() {
 	const [playing, setPlaying] = useState(false);
 	const [frameStart, setStart] = useState(0);
 	const [frameEnd, setEnd] = useState(0);
+	const [sdpInfo, setSdpInfo] = useState(false); //to toggle displaying SDP info popup
 	
 	const [selectedMarkers, setSelectedMarkers] = useState<number[]>([]);
 
@@ -171,11 +172,29 @@ export default function App() {
 				updateSelectedMarkers={setSelectedMarkers}
 			/>
 		</div>
-		<div id={"popup-area"}><ErrorPopup error={error} /></div>
+		<div id={"popup-area"}>
+			<ErrorPopup error={error} />
+			<div id={"sdp-info-popup"} style={sdpInfo ? {visibility: 'visible'} : {visibility: 'hidden'}}>
+				{`This website was created for a Boise State University
+				Computer Science Senior Design Project by
+				
+				Colin Reeder
+				Connor Jackson
+				Cory Tomlinson
+				Javier Trejo
+				William Kenny
+				
+				For information about sponsoring a project, go to
+				`}
+				<a href={"https://www.boisestate.edu/coen-cs/community/cs481-senior-design-project/"} target={'_blank'}>
+					https://www.boisestate.edu/coen-cs/community/cs481-senior-design-project/
+				</a>
+			</div>
+		</div>
 		<div id={"output-area"}>
 			<SelectionInfoView markerData={markerFileData} selectedMarkers={selectedMarkers} frame={frame} />
 		</div>
-		<img id={"sdp-logo"} src={sdpLogo} alt={"senior design project logo"} />
+		<img id={"sdp-logo"} src={sdpLogo} alt={"senior design project logo"} onClick={()=>setSdpInfo(!sdpInfo)} />
 		{/* ---------------------------------------------- Grid Row 4 ---------------------------------------------- */}
 		<div id={"timeline-track-area"}>
 			<div id="timeline-track-main-area">


### PR DESCRIPTION
Opens above the viz area within a "popup-area" container, which may be used for other large popups like error messages and the main menu.