### PR TITLE
define marker relations map for later rendering segments

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -171,27 +171,25 @@ export default function App() {
     // ------------------------------------------------- Body Segments -------------------------------------------------
 
     /* Array of pairs of marker indices; each pair defines a body segment */
-    const [segmentIndices, setSegmentIndices] = useState<Array<[number,number]|null>>([]);
-
-    /* Once marker file data is loaded, map the labeled segments to their corresponding marker indices for the renderer to use */
-    useEffect(() => {
+    const segmentIndices = useMemo<Array<[number,number]|null>>(() => {
+        /* Once marker file data is loaded, map the labeled segments to their corresponding marker indices for the renderer to use */
         if (markerFileData?.frames.length >= 1) {
             const labelToIdxMap = new Map<string, number>();
             markerFileData.markers.forEach((marker, idx) => {
                 labelToIdxMap.set(marker.label, idx);
             });
-            setSegmentIndices(
-                labeledSegments.map(seg => {
-                    const segStartIdx = labelToIdxMap.get(seg[0]);
-                    const segEndIdx = labelToIdxMap.get(seg[1]);
-                    if (segStartIdx!==undefined && segEndIdx!==undefined)
-                        return [segStartIdx, segEndIdx];
-                    else
-                        return null;
-                })
-            );
+            return labeledSegments.map(seg => {
+                const segStartIdx = labelToIdxMap.get(seg[0]);
+                const segEndIdx = labelToIdxMap.get(seg[1]);
+                if (segStartIdx!==undefined && segEndIdx!==undefined)
+                    return [segStartIdx, segEndIdx];
+                else
+                    return null;
+            });
         }
-    }, [markerFileData, setSegmentIndices]);
+        /* Before marker file data is loaded, there are no segments */
+        else return [];
+    }, [markerFileData]);
 
     // ---------------------------------------------------- Popups -----------------------------------------------------
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import TimelineTextView from "./views/TimelineTextView";
 
 import { ForceFileData, MarkerFileData } from "./dataTypes";
 import { MenuIcon } from "./icons";
+import { labeledSegments } from './segmentsConfig';
 
 import * as sdpLogo from "../assets/images/sdp-logo-3.png";
 
@@ -166,6 +167,31 @@ export default function App() {
 
     /* Array of the indices of the currently selected markers */
     const [selectedMarkers, setSelectedMarkers] = useState<number[]>([]);
+
+    // ------------------------------------------------- Body Segments -------------------------------------------------
+
+    /* Array of pairs of marker indices; each pair defines a body segment */
+    const [segmentIndices, setSegmentIndices] = useState<Array<[number,number]|null>>([]);
+
+    /* Once marker file data is loaded, map the labeled segments to their corresponding marker indices for the renderer to use */
+    useEffect(() => {
+        if (markerFileData?.frames.length >= 1) {
+            const labelToIdxMap = new Map<string, number>();
+            markerFileData.markers.forEach((marker, idx) => {
+                labelToIdxMap.set(marker.label, idx);
+            });
+            setSegmentIndices(
+                labeledSegments.map(seg => {
+                    const segStartIdx = labelToIdxMap.get(seg[0]);
+                    const segEndIdx = labelToIdxMap.get(seg[1]);
+                    if (segStartIdx!==undefined && segEndIdx!==undefined)
+                        return [segStartIdx, segEndIdx];
+                    else
+                        return null;
+                })
+            );
+        }
+    }, [markerFileData, setSegmentIndices]);
 
     // ---------------------------------------------------- Popups -----------------------------------------------------
 

--- a/src/segmentsConfig.ts
+++ b/src/segmentsConfig.ts
@@ -32,8 +32,8 @@ export const labeledSegments: [string,string][] = [
     ["LSHO","LLEB"], //outer arm
     ["LSHO","LMEB"], //inner arm
     ["LLEB","LMEB"], //elbow crease
-    ["LLEB","LMWRT"], //outer forearm
-    ["LMEB","LLWRT"], //inner forearm
+    ["LLEB","LLWRT"], //outer forearm
+    ["LMEB","LMWRT"], //inner forearm
     ["LLWRT","LMWRT"], //wrist crease
     ["LHAND","LLWRT"], //thumb side of hand
     ["LHAND","LMWRT"], //pinkie side of hand
@@ -42,8 +42,8 @@ export const labeledSegments: [string,string][] = [
     ["RSHO","RLEB"], //outer arm
     ["RSHO","RMEB"], //inner arm
     ["RLEB","RMEB"], //elbow crease
-    ["RLEB","RMWRT"], //outer forearm
-    ["RMEB","RLWRT"], //inner forearm
+    ["RLEB","RLWRT"], //outer forearm
+    ["RMEB","RMWRT"], //inner forearm
     ["RLWRT","RMWRT"], //wrist crease
     ["RHAND","RLWRT"], //thumb side of hand
     ["RHAND","RMWRT"], //pinkie side of hand

--- a/src/segmentsConfig.ts
+++ b/src/segmentsConfig.ts
@@ -1,0 +1,97 @@
+
+export const labeledSegments: [string,string][] = [
+
+    /* Head */
+    ["LFHD","RFHD"], //forehead
+    ["LBHD","RBHD"], //back of head
+    ["LFHD","LBHD"], //side of head
+    ["RFHD","RBHD"], //side of head
+
+    /* Center Torso */
+    ["LACR","RACR"], //collar bone
+    ["MID_HJC","MID_ASIS"], //groin front
+    ["MID_HJC","MID_PSIS"], //groin back
+
+    /* L Torso */
+    ["LILCR","LACR"], //upper side
+    ["LILCR","LGTR"], //lower side
+    ["LASIS","LGTR"], //outer front waist
+    ["LPSIS","LGTR"], //outer back waist
+    ["LASIS","MID_ASIS"], //inner front waist
+    ["LPSIS","MID_PSIS"], //inner back waist
+
+    /* R Torso */
+    ["RILCR","RACR"], //upper side
+    ["RILCR","RGTR"], //lower side
+    ["RASIS","RGTR"], //outer front waist
+    ["RPSIS","RGTR"], //outer back waist
+    ["RASIS","MID_ASIS"], //inner front waist
+    ["RPSIS","MID_PSIS"], //inner back waist
+
+    /* L Arm */
+    ["LSHO","LLEB"], //outer arm
+    ["LSHO","LMEB"], //inner arm
+    ["LLEB","LMEB"], //elbow crease
+    ["LLEB","LMWRT"], //outer forearm
+    ["LMEB","LLWRT"], //inner forearm
+    ["LLWRT","LMWRT"], //wrist crease
+    ["LHAND","LLWRT"], //thumb side of hand
+    ["LHAND","LMWRT"], //pinkie side of hand
+
+    /* R Arm */
+    ["RSHO","RLEB"], //outer arm
+    ["RSHO","RMEB"], //inner arm
+    ["RLEB","RMEB"], //elbow crease
+    ["RLEB","RMWRT"], //outer forearm
+    ["RMEB","RLWRT"], //inner forearm
+    ["RLWRT","RMWRT"], //wrist crease
+    ["RHAND","RLWRT"], //thumb side of hand
+    ["RHAND","RMWRT"], //pinkie side of hand
+
+    /* L Upper Leg */
+    ["LGTR","LLEP"], //outer leg
+    ["MID_HJC","LMEP"], //inner leg
+    ["LTHI","LLEP"], //outer top of kneecap
+    ["LTHI","LMEP"], //inner top of kneecap
+    ["LPSK","LLEP"], //outer bottom of kneecap
+    ["LPSK","LMEP"], //inner bottom of kneecap
+    ["LASIS","LTHI"], //front of thigh
+
+    /* L Lower Leg */
+    ["LLEP","LLMAL"], //outer calf
+    ["LMEP","LMMAL"], //inner calf
+    ["LDSK","LLMAL"], //outer front of ankle
+    ["LDSK","LMMAL"], //inner front of ankle
+    ["LDSK","LPSK"], //front of shin
+
+    /* L Foot */
+    ["LHEEL","LTOE"], //inner edge of foot
+    ["LHEEL","LMET5"], //outer edge of foot
+    ["LHEEL","LLMAL"], //outer top of heel
+    ["LHEEL","LMMAL"], //inner top of heel
+    ["LTOE","LMET5"], //toes
+
+    /* R Upper Leg */
+    ["RGTR","RLEP"], //outer leg
+    ["MID_HJC","RMEP"], //inner leg
+    ["RTHI","RLEP"], //outer top of kneecap
+    ["RTHI","RMEP"], //inner top of kneecap
+    ["RPSK","RLEP"], //outer bottom of kneecap
+    ["RPSK","RMEP"], //inner bottom of kneecap
+    ["RASIS","RTHI"], //front of thigh
+
+    /* R Lower Leg */
+    ["RLEP","RLMAL"], //outer calf
+    ["RMEP","RMMAL"], //inner calf
+    ["RDSK","RLMAL"], //outer front of ankle
+    ["RDSK","RMMAL"], //inner front of ankle
+    ["RDSK","RPSK"], //front of shin
+
+    /* R Foot */
+    ["RHEEL","RTOE"], //inner edge of foot
+    ["RHEEL","RMET5"], //outer edge of foot
+    ["RHEEL","RLMAL"], //outer top of heel
+    ["RHEEL","RMMAL"], //inner top of heel
+    ["RTOE","RMET5"], //toes
+
+];


### PR DESCRIPTION
Defines body segments in a config file using a list of pairs of marker labels (so that the configuration is human-readable), which are later mapped to the corresponding pairs of marker indices in the loaded data so the renderer only needs to index into the marker positions array to animate them.