### PR TITLE
render and animate segments

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -228,6 +228,7 @@ export default function App() {
         {/* --------------------------------------------- Grid Row 2-3 --------------------------------------------- */}
         <RenderView frame={frame} markerData={markerFileData} forceData={forceFileData}
                     selectedMarkers={selectedMarkers} setSelectedMarkers={setSelectedMarkers}
+                    segmentIndices={segmentIndices}
         />
         <PopupView error={error} sdpInfo={sdpInfo} menu={menu}
         />


### PR DESCRIPTION
Self explanatory. The THREE.BufferAttribute 'position' approach seems to be the most performant line animation option I could find, as suggested here https://dustinpfister.github.io/2021/06/07/threejs-buffer-geometry-attributes-position/

It doesn't read quite as nicely as my initial solution which used
```typescript
seg.geometry.setFromPoints([convertCoordsViconToThree(startPos),convertCoordsViconToThree(endPos)]);
```
however, this produces unnecessary garbage and the author above indicates having run into problems with this approach.